### PR TITLE
Call super.updateConstraints() in SegmentedCell

### DIFF
--- a/Source/Rows/SegmentedRow.swift
+++ b/Source/Rows/SegmentedRow.swift
@@ -139,7 +139,10 @@ open class SegmentedCell<T: Equatable> : Cell<T>, CellType {
     }
 
     open override func updateConstraints() {
-        guard !awakeFromNibCalled else { return }
+        guard !awakeFromNibCalled else { 
+            super.updateConstraints()
+            return 
+        }
         contentView.removeConstraints(dynamicConstraints)
         dynamicConstraints = []
         var views: [String: AnyObject] =  ["segmentedControl": segmentedControl]


### PR DESCRIPTION
Without that, we have crash for SegmentedCell with xib. Description of crash tells that we didn't call `super.updateConstraints()`

